### PR TITLE
Add @yhl125/custom-plugin-mcp@0.0.1

### DIFF
--- a/index.json
+++ b/index.json
@@ -115,5 +115,23 @@
       "project": [],
       "module": []
     }
+  },
+  "v2": {
+    "packages": {
+      "@yhl125/custom-plugin-mcp": {
+        "name": "@yhl125/custom-plugin-mcp",
+        "description": "ElizaOS plugin to integrate with MCP (Model Context Protocol) servers",
+        "type": "plugin",
+        "versions": {
+          "0.0.1": {
+            "version": "0.0.1",
+            "runtimeVersion": "1.0.0-beta.28",
+            "platform": "universal",
+            "publishedAt": "2025-04-12T16:53:59.306Z",
+            "published": true
+          }
+        }
+      }
+    }
   }
 }

--- a/packages/@yhl125/custom-plugin-mcp/0.0.1.json
+++ b/packages/@yhl125/custom-plugin-mcp/0.0.1.json
@@ -1,0 +1,23 @@
+{
+  "name": "@yhl125/custom-plugin-mcp",
+  "version": "0.0.1",
+  "description": "ElizaOS plugin to integrate with MCP (Model Context Protocol) servers",
+  "type": "plugin",
+  "platform": "universal",
+  "runtimeVersion": "1.0.0-beta.28",
+  "repository": "git+https://github.com/fleek-platform/eliza-plugin-mcp.git",
+  "maintainers": [
+    "yhl125"
+  ],
+  "publishedAt": "2025-04-12T16:53:59.306Z",
+  "publishedBy": "yhl125",
+  "dependencies": {
+    "@elizaos/core": "1.0.0-beta.28",
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "ajv": "^8.17.1",
+    "json5": "^2.2.3"
+  },
+  "tags": [],
+  "license": "MIT",
+  "npmPackage": "@yhl125/custom-plugin-mcp"
+}


### PR DESCRIPTION

## New Plugin/Project Submission

- Name: @yhl125/custom-plugin-mcp
- Version: 0.0.1
- Type: plugin
- Platform: universal
- Description: ElizaOS plugin to integrate with MCP (Model Context Protocol) servers
- Runtime Version: 1.0.0-beta.28

Submitted by: @yhl125
			