### PR TITLE
Add @elizaos/plugin-gtk@1.0.0 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "@elizaos/plugin-gtk": "packages/plugin-gtk.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "@elizaos/plugin-gtk"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-gtk.json
+++ b/packages/plugin-gtk.json
@@ -1,0 +1,39 @@
+{
+  "name": "@elizaos/plugin-gtk",
+  "description": "ElizaOS plugin for Sifchain GTK margin trading platform",
+  "repository": {
+    "type": "git",
+    "url": "github:Samarthsinghal28/plugin-gtk"
+  },
+  "maintainers": [
+    {
+      "name": "Samarthsinghal28",
+      "github": "Samarthsinghal28"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "elizaos",
+    "plugin",
+    "sifchain",
+    "gtk",
+    "trading",
+    "margin",
+    "cryptocurrency"
+  ],
+  "versions": [
+    {
+      "version": "1.0.0",
+      "gitBranch": "1.0.0",
+      "gitTag": "v1.0.0",
+      "runtimeVersion": "1.0.0-beta.28",
+      "releaseDate": "2025-04-12T17:43:44.048Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": "1.0.0",
+  "latestVersion": "1.0.0",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds @elizaos/plugin-gtk version 1.0.0 to the registry.

- Type: module
- Installable: No - Project type
- Package name: @elizaos/plugin-gtk
- Version: 1.0.0
- Runtime version: 1.0.0-beta.28
- Description: ElizaOS plugin for Sifchain GTK margin trading platform
- Repository: github:Samarthsinghal28/plugin-gtk
- Platform: universal
- Categories: none
- Tags: elizaos, plugin, sifchain, gtk, trading, margin, cryptocurrency

Submitted by: @Samarthsinghal28