### PR TITLE
Add @elizaos/plugin-livepeer@1.0.0-beta.33 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "@elizaos/plugin-livepeer": "packages/plugin-livepeer.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "@elizaos/plugin-livepeer"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-livepeer.json
+++ b/packages/plugin-livepeer.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-livepeer",
+  "description": "Livepeer inference plugin for elizaOS",
+  "repository": {
+    "type": "git",
+    "url": "github:UD1sto/plugin-livepeer-inference"
+  },
+  "maintainers": [
+    {
+      "name": "UD1sto",
+      "github": "UD1sto"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin"
+  ],
+  "versions": [
+    {
+      "version": "1.0.0-beta.33",
+      "gitBranch": "1.0.0-beta.33",
+      "gitTag": "v1.0.0-beta.33",
+      "runtimeVersion": "1.0.0-beta.34",
+      "releaseDate": "2025-04-24T18:01:20.484Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": null,
+  "latestVersion": "1.0.0-beta.33",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds @elizaos/plugin-livepeer version 1.0.0-beta.33 to the registry.

- Type: module
- Installable: No - Project type
- Package name: @elizaos/plugin-livepeer
- Version: 1.0.0-beta.33
- Runtime version: 1.0.0-beta.34
- Description: Livepeer inference plugin for elizaOS
- Repository: github:UD1sto/plugin-livepeer-inference
- Platform: universal
- Categories: none
- Tags: plugin

Submitted by: @UD1sto