### PR TITLE
Add @elizaos/plugin-akash-chat@1.0.0-beta.35 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "@elizaos/plugin-akash-chat": "packages/plugin-akash-chat.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "@elizaos/plugin-akash-chat"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-akash-chat.json
+++ b/packages/plugin-akash-chat.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-akash-chat",
+  "description": "Plugin starter for elizaOS",
+  "repository": {
+    "type": "git",
+    "url": "github:elizaos-plugins/plugin-akash-chat"
+  },
+  "maintainers": [
+    {
+      "name": "fenilmodi00",
+      "github": "fenilmodi00"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin"
+  ],
+  "versions": [
+    {
+      "version": "1.0.0-beta.35",
+      "gitBranch": "1.0.0-beta.35",
+      "gitTag": "v1.0.0-beta.35",
+      "runtimeVersion": "1.0.0-beta.37",
+      "releaseDate": "2025-04-25T04:11:58.748Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": null,
+  "latestVersion": "1.0.0-beta.35",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds @elizaos/plugin-akash-chat version 1.0.0-beta.35 to the registry.

- Type: plugin
- Installable: Yes
- Package name: @elizaos/plugin-akash-chat
- Version: 1.0.0-beta.35
- Runtime version: 1.0.0-beta.37
- Description: Plugin starter for elizaOS
- Repository: github:elizaos-plugins/plugin-akash-chat
- Platform: universal
- Categories: none
- Tags: plugin

Submitted by: @fenilmodi00