### PR TITLE
Add @elizaos/plugin-filecoin@1.0.0 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "@elizaos/plugin-filecoin": "packages/plugin-filecoin.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "@elizaos/plugin-filecoin"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-filecoin.json
+++ b/packages/plugin-filecoin.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-filecoin",
+  "description": "A plugin for ElizaOS that provides creative storage solutions using Filecoin and IPFS.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jhead12/elizaos-plugins/plugin-filecoin"
+  },
+  "maintainers": [
+    {
+      "name": "jhead12",
+      "github": "jhead12"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin"
+  ],
+  "versions": [
+    {
+      "version": "1.0.0",
+      "gitBranch": "1.0.0",
+      "gitTag": "v1.0.0",
+      "runtimeVersion": "1.0.0-beta.27",
+      "releaseDate": "2025-05-02T08:49:02.399Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": "1.0.0",
+  "latestVersion": "1.0.0",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds @elizaos/plugin-filecoin version 1.0.0 to the registry.

- Type: plugin
- Installable: Yes
- Package name: @elizaos/plugin-filecoin
- Version: 1.0.0
- Runtime version: 1.0.0-beta.27
- Description: A plugin for ElizaOS that provides creative storage solutions using Filecoin and IPFS.
- Repository: https://github.com/jhead12/elizaos-plugins/plugin-filecoin
- Platform: universal
- Categories: none
- Tags: plugin

Submitted by: @jhead12