### PR TITLE
Add @elizaos/plugin-web3-connector@1.0.0 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "@elizaos/plugin-web3-connector": "packages/plugin-web3-connector.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "@elizaos/plugin-web3-connector"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-web3-connector.json
+++ b/packages/plugin-web3-connector.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-web3-connector",
+  "description": "A plugin for ElizaOS that provides creative storage solutions using Filecoin and IPFS.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jhead12/elizaos-plugins/plugin-filecoin"
+  },
+  "maintainers": [
+    {
+      "name": "jhead12",
+      "github": "jhead12"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin"
+  ],
+  "versions": [
+    {
+      "version": "1.0.0",
+      "gitBranch": "1.0.0",
+      "gitTag": "v1.0.0",
+      "runtimeVersion": "1.0.0-beta.27",
+      "releaseDate": "2025-05-02T08:55:38.148Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": "1.0.0",
+  "latestVersion": "1.0.0",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds @elizaos/plugin-web3-connector version 1.0.0 to the registry.

- Type: plugin
- Installable: Yes
- Package name: @elizaos/plugin-web3-connector
- Version: 1.0.0
- Runtime version: 1.0.0-beta.27
- Description: A plugin for ElizaOS that provides creative storage solutions using Filecoin and IPFS.
- Repository: https://github.com/jhead12/elizaos-plugins/plugin-filecoin
- Platform: universal
- Categories: none
- Tags: plugin

Submitted by: @jhead12