### PR TITLE
Add @elizaos/plugin-proagent@1.0.0-beta.40 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "@elizaos/plugin-proagent": "packages/plugin-proagent.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "@elizaos/plugin-proagent"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-proagent.json
+++ b/packages/plugin-proagent.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-proagent",
+  "description": "Plugin starter for elizaOS",
+  "repository": {
+    "type": "git",
+    "url": "github:elizaos-plugins/plugin-proagent"
+  },
+  "maintainers": [
+    {
+      "name": "blackflame007",
+      "github": "blackflame007"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin"
+  ],
+  "versions": [
+    {
+      "version": "1.0.0-beta.40",
+      "gitBranch": "1.0.0-beta.40",
+      "gitTag": "v1.0.0-beta.40",
+      "runtimeVersion": "1.0.0-beta.41",
+      "releaseDate": "2025-05-05T22:28:20.718Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": null,
+  "latestVersion": "1.0.0-beta.40",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds @elizaos/plugin-proagent version 1.0.0-beta.40 to the registry.

- Type: plugin
- Installable: Yes
- Package name: @elizaos/plugin-proagent
- Version: 1.0.0-beta.40
- Runtime version: 1.0.0-beta.41
- Description: Plugin starter for elizaOS
- Repository: github:elizaos-plugins/plugin-proagent
- Platform: universal
- Categories: none
- Tags: plugin

Submitted by: @blackflame007