### PR TITLE
Add plugin-payid-eliza v0.0.1 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "plugin-payid-eliza": "packages/plugin-payid-eliza.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "plugin-payid-eliza"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-payid-eliza.json
+++ b/packages/plugin-payid-eliza.json
@@ -1,0 +1,33 @@
+{
+  "name": "plugin-payid-eliza",
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "github:metabaronespinosa/plugin-payid-eliza"
+  },
+  "maintainers": [
+    {
+      "name": "metabaronespinosa",
+      "github": "metabaronespinosa"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin"
+  ],
+  "versions": [
+    {
+      "version": "0.0.1",
+      "gitBranch": "0.0.1",
+      "gitTag": "v0.0.1",
+      "runtimeVersion": "1.0.0-beta.48",
+      "releaseDate": "2025-05-08T00:33:47.640Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": "0.0.1",
+  "latestVersion": "0.0.1",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}

--- a/packages/plugin-payid-eliza.json
+++ b/packages/plugin-payid-eliza.json
@@ -21,7 +21,7 @@
       "gitBranch": "0.0.1",
       "gitTag": "v0.0.1",
       "runtimeVersion": "1.0.0-beta.48",
-      "releaseDate": "2025-05-08T00:33:47.640Z",
+      "releaseDate": "2025-05-08T00:34:41.726Z",
       "deprecated": false
     }
   ],


### PR DESCRIPTION
This PR adds plugin-payid-eliza version 0.0.1 to the registry.

- Type: plugin
- Installable: Yes
- Package name: plugin-payid-eliza
- Version: 0.0.1
- Runtime version: 1.0.0-beta.48
- Description: No description provided
- Repository: github:metabaronespinosa/plugin-payid-eliza
- Platform: universal
- Categories: none
- Tags: plugin

Submitted by: @metabaronespinosa