### PR TITLE
Add @elizaos/plugin-loralab v0.1.0 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "@elizaos/plugin-loralab": "packages/plugin-loralab.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "@elizaos/plugin-loralab"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-loralab.json
+++ b/packages/plugin-loralab.json
@@ -1,0 +1,37 @@
+{
+  "name": "@elizaos/plugin-loralab",
+  "description": "LoraLab image & video generation plugin for elizaOS",
+  "repository": {
+    "type": "git",
+    "url": "github:ta-da-dev/plugin-loralab"
+  },
+  "maintainers": [
+    {
+      "name": "ta-da-dev",
+      "github": "ta-da-dev"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin",
+    "elizaos",
+    "image-generation",
+    "video-generation",
+    "loralab"
+  ],
+  "versions": [
+    {
+      "version": "0.1.0",
+      "gitBranch": "0.1.0",
+      "gitTag": "v0.1.0",
+      "runtimeVersion": "1.0.0-beta.49",
+      "releaseDate": "2025-05-12T08:40:16.204Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": "0.1.0",
+  "latestVersion": "0.1.0",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds @elizaos/plugin-loralab version 0.1.0 to the registry.

- Type: plugin
- Installable: Yes
- Package name: @elizaos/plugin-loralab
- Version: 0.1.0
- Runtime version: 1.0.0-beta.49
- Description: LoraLab image & video generation plugin for elizaOS
- Repository: github:ta-da-dev/plugin-loralab
- Platform: universal
- Categories: none
- Tags: plugin, elizaos, image-generation, video-generation, loralab

Submitted by: @ta-da-dev