### PR TITLE
Add @elizaos/plugin-akash-chat v1.0.0-beta.35 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "@elizaos/plugin-akash-chat": "packages/plugin-akash-chat.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "@elizaos/plugin-akash-chat"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-akash-chat.json
+++ b/packages/plugin-akash-chat.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-akash-chat",
+  "description": "This plugin integrates Akash Chat API with ElizaOS, providing a complete replacement for OpenAI API functionality. It supports text generation, embeddings, tokenization, and object generation.",
+  "repository": {
+    "type": "git",
+    "url": "github:fenilmodi00/plugin-akash-chat"
+  },
+  "maintainers": [
+    {
+      "name": "fenilmodi00",
+      "github": "fenilmodi00"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin"
+  ],
+  "versions": [
+    {
+      "version": "1.0.0-beta.35",
+      "gitBranch": "1.0.0-beta.35",
+      "gitTag": "v1.0.0-beta.35",
+      "runtimeVersion": "1.0.0-beta.49",
+      "releaseDate": "2025-05-13T06:09:24.770Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": null,
+  "latestVersion": "1.0.0-beta.35",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds @elizaos/plugin-akash-chat version 1.0.0-beta.35 to the registry.

- Type: plugin
- Installable: Yes
- Package name: @elizaos/plugin-akash-chat
- Version: 1.0.0-beta.35
- Runtime version: 1.0.0-beta.49
- Description: This plugin integrates Akash Chat API with ElizaOS, providing a complete replacement for OpenAI API functionality. It supports text generation, embeddings, tokenization, and object generation.
- Repository: github:fenilmodi00/plugin-akash-chat
- Platform: universal
- Categories: none
- Tags: plugin

Submitted by: @fenilmodi00