### PR TITLE
Add plugin-payid-eliza v0.0.2 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "plugin-payid-eliza": "packages/plugin-payid-eliza.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "plugin-payid-eliza"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-payid-eliza.json
+++ b/packages/plugin-payid-eliza.json
@@ -1,0 +1,33 @@
+{
+  "name": "plugin-payid-eliza",
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "github:metabaronespinosa/plugin-payid-eliza"
+  },
+  "maintainers": [
+    {
+      "name": "metabaronespinosa",
+      "github": "metabaronespinosa"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin"
+  ],
+  "versions": [
+    {
+      "version": "0.0.2",
+      "gitBranch": "0.0.2",
+      "gitTag": "v0.0.2",
+      "runtimeVersion": "1.0.0-beta.49",
+      "releaseDate": "2025-05-13T22:39:21.926Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": "0.0.2",
+  "latestVersion": "0.0.2",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds plugin-payid-eliza version 0.0.2 to the registry.

- Type: plugin
- Installable: Yes
- Package name: plugin-payid-eliza
- Version: 0.0.2
- Runtime version: 1.0.0-beta.49
- Description: No description provided
- Repository: github:metabaronespinosa/plugin-payid-eliza
- Platform: universal
- Categories: none
- Tags: plugin

Submitted by: @metabaronespinosa