### PR TITLE
Add @elizaos/plugin-polygon@1.0.0-beta.40 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "@elizaos/plugin-polygon": "packages/plugin-polygon.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "@elizaos/plugin-polygon"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-polygon.json
+++ b/packages/plugin-polygon.json
@@ -21,7 +21,7 @@
       "gitBranch": "1.0.0-beta.40",
       "gitTag": "v1.0.0-beta.40",
       "runtimeVersion": "1.0.0-beta.41",
-      "releaseDate": "2025-05-18T03:12:48.062Z",
+      "releaseDate": "2025-05-25T19:14:21.835Z",
       "deprecated": false
     }
   ],

--- a/packages/plugin-polygon.json
+++ b/packages/plugin-polygon.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-polygon",
+  "description": "Polygon integration for ElizaOS",
+  "repository": {
+    "type": "git",
+    "url": "github:elizaos-plugins/plugin-polygon"
+  },
+  "maintainers": [
+    {
+      "name": "Samarthsinghal28",
+      "github": "Samarthsinghal28"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin"
+  ],
+  "versions": [
+    {
+      "version": "1.0.0-beta.40",
+      "gitBranch": "1.0.0-beta.40",
+      "gitTag": "v1.0.0-beta.40",
+      "runtimeVersion": "1.0.0-beta.41",
+      "releaseDate": "2025-05-18T03:12:48.062Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": null,
+  "latestVersion": "1.0.0-beta.40",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds @elizaos/plugin-polygon version 1.0.0-beta.40 to the registry.

- Type: plugin
- Installable: Yes
- Package name: @elizaos/plugin-polygon
- Version: 1.0.0-beta.40
- Runtime version: 1.0.0-beta.41
- Description: Polygon integration for ElizaOS
- Repository: github:elizaos-plugins/plugin-polygon
- Platform: universal
- Categories: none
- Tags: plugin

Submitted by: @Samarthsinghal28