### PR TITLE
Add @elizaos/plugin-reveel-payid v0.0.3 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -105,12 +105,14 @@
   "__v2": {
     "version": "2.0.0",
     "packages": {
-      "@elizaos/plugin-starter": "packages/plugin-starter.json"
+      "@elizaos/plugin-starter": "packages/plugin-starter.json",
+      "@elizaos/plugin-reveel-payid": "packages/plugin-reveel-payid.json"
     },
     "categories": {},
     "types": {
       "plugin": [
-        "@elizaos/plugin-starter"
+        "@elizaos/plugin-starter",
+        "@elizaos/plugin-reveel-payid"
       ],
       "project": [],
       "module": []

--- a/packages/plugin-reveel-payid.json
+++ b/packages/plugin-reveel-payid.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-reveel-payid",
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "github:metabaronespinosa/plugin-payid"
+  },
+  "maintainers": [
+    {
+      "name": "metabaronespinosa",
+      "github": "metabaronespinosa"
+    }
+  ],
+  "categories": [],
+  "tags": [
+    "plugin"
+  ],
+  "versions": [
+    {
+      "version": "0.0.3",
+      "gitBranch": "0.0.3",
+      "gitTag": "v0.0.3",
+      "runtimeVersion": "1.0.0-beta.57",
+      "releaseDate": "2025-05-26T14:48:53.633Z",
+      "deprecated": false
+    }
+  ],
+  "latestStable": "0.0.3",
+  "latestVersion": "0.0.3",
+  "type": "plugin",
+  "installable": true,
+  "platform": "universal"
+}


### PR DESCRIPTION
This PR adds @elizaos/plugin-reveel-payid version 0.0.3 to the registry.

- Type: plugin
- Installable: Yes
- Package name: @elizaos/plugin-reveel-payid
- Version: 0.0.3
- Runtime version: 1.0.0-beta.57
- Description: No description provided
- Repository: github:metabaronespinosa/plugin-payid
- Platform: universal
- Categories: none
- Tags: plugin

Submitted by: @metabaronespinosa